### PR TITLE
Update busybox-inittab_1.31.0.bb

### DIFF
--- a/meta/recipes-core/busybox/busybox-inittab_1.31.0.bb
+++ b/meta/recipes-core/busybox/busybox-inittab_1.31.0.bb
@@ -21,7 +21,7 @@ do_install() {
 	do
 		j=`echo ${i} | sed s/\;/\ /g`
 		id=`echo ${i} | sed -e 's/^.*;//' -e 's/;.*//'`
-		echo "$id::respawn:${base_sbindir}/getty ${j}" >> ${D}${sysconfdir}/inittab
+		echo "$id::respawn:${base_sbindir}/getty -L ${j}" >> ${D}${sysconfdir}/inittab
 	done
 }
 


### PR DESCRIPTION
The parameter  "-L " should be added after getty
---------------------------------------------------------
reason:
In the case of ttyS0, some systems will point  [/dev/stdout] to [/dev/ttyS0],
If the "-L" parameter is not added, writing data to [/dev/stdout] will cause blocking