### PR TITLE
devtools pseudo-native: fix compilation on gcc 10.1.0

### DIFF
--- a/meta/recipes-devtools/pseudo/pseudo.inc
+++ b/meta/recipes-devtools/pseudo/pseudo.inc
@@ -29,6 +29,8 @@ NO32LIBS_class-nativesdk = "1"
 
 PSEUDO_EXTRA_OPTS ?= "--enable-force-async --without-passwd-fallback --enable-epoll --enable-xattr"
 
+BUILD_CFLAGS += "-Wl,--allow-multiple-definition"
+
 # Compile for the local machine arch...
 do_compile () {
 	if [ "${SITEINFO_BITS}" = "64" ]; then


### PR DESCRIPTION
fixed pseudo-native compilation on gcc 10

the specific issue was:
`
| pseudo_util.o:/home/adam/projects/project/build/tmp/work/x86_64-linux/pseudo-native/1.9.0+gitAUTOINC+060058bb29-r0/git/pseudo_ipc.h:37: multiple definition of pseudo_access_t'; pseudolog.o:/home/adam/projects/project/build/tmp/work/x86_64-linux/pseudo-native/1.9.0+gitAUTOINC+060058bb29-r0/git/pseudo_ipc.h:37: first defined here`

rather than fixing package I have passed linker flag, this issue is reproducible on gcc 10 compiler on recently updated arch and fedora32 
