### PR TITLE
meta ppp: add initscripts-functions rdepends

### DIFF
--- a/meta/recipes-connectivity/ppp/ppp_2.4.7.bb
+++ b/meta/recipes-connectivity/ppp/ppp_2.4.7.bb
@@ -86,6 +86,7 @@ do_install_append_libc-musl () {
 	install -Dm 0644 ${S}/include/net/ppp_defs.h ${D}${includedir}/net/ppp_defs.h
 }
 
+RDEPENDS_${PN} = "initscripts-functions"
 CONFFILES_${PN} = "${sysconfdir}/ppp/pap-secrets ${sysconfdir}/ppp/chap-secrets ${sysconfdir}/ppp/options"
 PACKAGES =+ "${PN}-oa ${PN}-oe ${PN}-radius ${PN}-winbind ${PN}-minconn ${PN}-password ${PN}-l2tp ${PN}-tools"
 FILES_${PN}        = "${sysconfdir} ${bindir} ${sbindir}/chat ${sbindir}/pppd ${systemd_unitdir}/system/ppp@.service"


### PR DESCRIPTION
ppp init script requires /etc/init.d/functions so reflect
this is recipe

Signed-off-by: Adam Miartus <adam.miartus@softhows.eu>