### PR TITLE
resolvconf: add missing dependencies to RDEPENDS

### DIFF
--- a/meta/recipes-connectivity/resolvconf/resolvconf_1.87.bb
+++ b/meta/recipes-connectivity/resolvconf/resolvconf_1.87.bb
@@ -9,7 +9,7 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=c93c0550bd3173f4504b2cbd8991e50b"
 AUTHOR = "Thomas Hood"
 HOMEPAGE = "http://packages.debian.org/resolvconf"
-RDEPENDS_${PN} = "bash"
+RDEPENDS_${PN} = "bash coreutils util-linux"
 
 SRC_URI = "git://salsa.debian.org/debian/resolvconf.git;protocol=https;branch=unstable \
            file://fix-path-for-busybox.patch \


### PR DESCRIPTION
resolvconf uses flock and readlink.
So explicitly added dependencies on util-linux (for flock) and coreutils
(for readlink).
Note that the options used with flock and readlink are not part of the
busybox implementations so full-fledged implementations are needed.